### PR TITLE
Fix : bug  when querying admins in PM with shieldy

### DIFF
--- a/src/middlewares/checkNoChannelLinks.ts
+++ b/src/middlewares/checkNoChannelLinks.ts
@@ -15,7 +15,7 @@ export async function checkNoChannelLinks(
     if (!ctx.dbchat.noChannelLinks) {
         return next()
     }
-    if (ctx.from.id === parseInt(process.env.ADMIN) || (await ctx.getChatAdministrators()).filter(admin => admin.user.id === ctx.from.id).length > 0) {
+    if (ctx.from.id === parseInt(process.env.ADMIN) || (ctx.chat.type != 'private' && (await ctx.getChatAdministrators()).filter(admin => admin.user.id === ctx.from.id).length > 0)) {
         return next()
     }
     // For each of the links contained in the message


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40718516/72921612-80ba0800-3d43-11ea-899c-0ab86e02066f.png)

Fix `Error 400: Bad Request: there is no administrators in the private chat`
In the last commit of PR #62 I added a check :
If the sender of the message is Administrator, do not delete it

But only tested it in public chat rooms, not in PMs

Turns out `context.getChatAdministrators()` returns an error if called in a Private chat