### PR TITLE
Fix portuguese `/greeting` message

### DIFF
--- a/src/helpers/localizations.ts
+++ b/src/helpers/localizations.ts
@@ -858,7 +858,7 @@ export const localizations = {
     uk:
       'Чудово! Тепер щойно новачки розвʼяжуть капчу вони отримають вітання. У відповідь на це повідомлення надішліть текст вітання, яким бажаєте зустрічати майбутніх користувачів (можете використовувати $title, $fullname та $username).',
     br:
-      'Boa! Agora os novatos que passarem no teste não serão congratulados. Por favor, responda essa mensagem com a o texto de congratulações que você gostaria de usar.',
+      'Boa! Agora os novatos que passarem no teste serão congratulados. Por favor, responda essa mensagem com a o texto de congratulações que você gostaria de usar.',
     tr:
       'Harika! Artık testi geçen yeni üyeler karşılanacak. Lütfen, bu iletiyi kullanmak istediğiniz tebrik metniyle yanıtlayın ($title ve $username kullanabilirsiniz).',
     es:


### PR DESCRIPTION
Removed the "não" (not) that indicated that the newcomers wouldn't be greeted, when they're actually GOING to.