### PR TITLE
Substitute equazione with espressione in italian translation

### DIFF
--- a/src/helpers/localizations.ts
+++ b/src/helpers/localizations.ts
@@ -579,7 +579,7 @@ export const localizations = {
     ru:
       ', пожалуйста, отправьте решение указанной арифметической задачи в этот чат в течение указанного времени, иначе вы будете кикнуты. Спасибо!',
     it:
-      ", prego, invia la soluzione dell'equazione matematica in questo gruppo entro il tempo specificato, altrimenti verrai kickato. Grazie!",
+      ", prego, invia la soluzione dell'espressione matematica in questo gruppo entro il tempo specificato, altrimenti verrai kickato. Grazie!",
     et:
       ', palun saatke matemaatilise võrrandi lahendus sellele vestlusele määratud aja jooksul, muidu me kickime teid. Aitäh!',
     uk:


### PR DESCRIPTION
The bot show an mathematical expression (format 2+3) instead of a mathematical equation (format 2+3=x), this MR correct the term for the italian transaltion.