### PR TITLE
[docker-compose] Bump up version to 3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.1"
 
 services:
   shieldy:


### PR DESCRIPTION
Ref.: https://github.com/backmeupplz/shieldy/issues/119

Thank you for the suggestion, @DolanKivert
